### PR TITLE
Updated imports to be compatible with aiohttp 1.1.0

### DIFF
--- a/snare.py
+++ b/snare.py
@@ -29,8 +29,11 @@ import configparser
 import git
 import multiprocessing
 import aiohttp
-from aiohttp.web import StaticRoute
 from aiohttp import MultiDict
+try:
+    from aiohttp.web import StaticResource as StaticRoute
+except ImportError:
+    from aiohttp.web import StaticRoute
 
 from bs4 import BeautifulSoup
 import cssutils


### PR DESCRIPTION
aiohttp 1.1.0 replaces StaticRoute with StaticResource (see [changelog](https://github.com/KeepSafe/aiohttp/blob/master/CHANGES.rst)).

Wrapped the new import in a try-except and alias StaticResource as StaticRoute to preserve compatibility with pervious versions of aiohttp.

I tested this with aiohttp 1.1.1 and 1.0.5, and both work.