### PR TITLE
Feature/cloner improvements

### DIFF
--- a/clone.py
+++ b/clone.py
@@ -123,7 +123,7 @@ class Cloner(object):
 
         if file_name == '/' or file_name == "":
             if host == self.root.host or (self.moved_root is not None and self.moved_root.host == host):
-                file_name = 'index.html'
+                file_name = '/index.html'
             else:
                 file_name = host
         m = hashlib.md5()

--- a/clone.py
+++ b/clone.py
@@ -66,9 +66,9 @@ class Cloner(object):
         host = url.host
 
         if check_host:
-            if (host != self.root.host and
-                    (self.moved_root is not None and host != self.moved_root.host)) or \
-                    url.fragment:
+            if (host != self.root.host and self.moved_root is None) or \
+                    url.fragment or \
+                    (self.moved_root is not None and host != self.moved_root.host):
                 return None
 
         if url.human_repr() not in self.visited_urls:
@@ -144,6 +144,7 @@ class Cloner(object):
                     response = yield from session.get(current_url)
                     content_type = response.content_type
                     data = yield from response.read()
+
             except (aiohttp.ClientError, asyncio.TimeoutError) as client_error:
                 print(client_error)
             else:
@@ -173,6 +174,7 @@ class Cloner(object):
             resp = yield from session.get(self.root)
             if resp._url_obj.host != self.root.host:
                 self.moved_root = resp._url_obj
+            resp.close()
 
     @asyncio.coroutine
     def run(self):

--- a/clone.py
+++ b/clone.py
@@ -60,7 +60,8 @@ class Cloner(object):
         if not url.is_absolute():
             url = self.root.join(url)
 
-        yield from self.new_urls.put(url)
+        if url.human_repr() not in self.visited_urls:
+            yield from self.new_urls.put(url)
         return url.relative().human_repr()
 
     @asyncio.coroutine
@@ -105,9 +106,9 @@ class Cloner(object):
     def get_body(self, session):
         while not self.new_urls.empty():
             current_url = yield from self.new_urls.get()
-            if current_url in self.visited_urls:
+            if current_url.human_repr() in self.visited_urls:
                 continue
-            self.visited_urls.append(current_url)
+            self.visited_urls.append(current_url.human_repr())
             file_name, hash_name = self._make_filename(current_url)
             print('name: ', file_name)
             self.meta[file_name] = {}

--- a/clone.py
+++ b/clone.py
@@ -116,6 +116,9 @@ class Cloner(object):
             file_name = url.relative().human_repr()
         else:
             file_name = url.human_repr()
+        if not file_name.startswith('/'):
+            file_name = "/"+file_name
+
         if file_name == '/' or file_name == "":
             if host == self.root.host or (self.moved_root is not None and self.moved_root.host == host):
                 file_name = 'index.html'

--- a/clone.py
+++ b/clone.py
@@ -17,10 +17,10 @@ GNU General Public License for more details.
 import argparse
 import asyncio
 import hashlib
+import json
 import os
 import re
 import sys
-import json
 from asyncio import Queue
 
 import aiohttp
@@ -54,15 +54,30 @@ class Cloner(object):
     @asyncio.coroutine
     def process_link(self, url, check_host=False):
         url = yarl.URL(url)
-        if check_host:
-            if url.host != self.root.host or url.fragment:
-                return None
+        if url.scheme == ("data" or "javascript"):
+            return url.human_repr()
         if not url.is_absolute():
             url = self.root.join(url)
+        #get subdomains
+        host = url.host
+        if host is not None:
+            host_parts = host.split(".")
+
+            if len(host_parts) > 2:
+                host = host_parts[-2]+"."+host_parts[-1]
+
+        if check_host:
+            if host != self.root.host or url.fragment:
+                return None
 
         if url.human_repr() not in self.visited_urls:
             yield from self.new_urls.put(url)
-        return url.relative().human_repr()
+
+        try:
+            res = url.relative().human_repr()
+        except ValueError:
+            print(url)
+        return res
 
     @asyncio.coroutine
     def replace_links(self, data):
@@ -94,9 +109,13 @@ class Cloner(object):
         return soup
 
     def _make_filename(self, url):
+        host  = url.host
         file_name = url.relative().human_repr()
         if file_name == '/' or file_name == "":
-            file_name = 'index.html'
+            if host == self.root.host:
+                file_name = 'index.html'
+            else:
+                file_name = host
         m = hashlib.md5()
         m.update(file_name.encode('utf-8'))
         hash_name = m.hexdigest()
@@ -123,7 +142,7 @@ class Cloner(object):
             except (aiohttp.ClientError, asyncio.TimeoutError) as client_error:
                 print(client_error)
             else:
-                response.release()
+                yield from response.release()
             if data is not None:
                 self.meta[file_name]['hash'] = hash_name
                 self.meta[file_name]['content_type'] = content_type
@@ -146,11 +165,16 @@ class Cloner(object):
     @asyncio.coroutine
     def run(self):
         session = aiohttp.ClientSession()
-        yield from self.new_urls.put(self.root)
-        yield from self.get_body(session)
-        with open(os.path.join(self.target_path,'meta.json'), 'w') as mj:
-            json.dump(self.meta,mj)
-        session.close()
+        try:
+            yield from self.new_urls.put(self.root)
+            yield from self.get_body(session)
+        except KeyboardInterrupt:
+            raise
+        finally:
+            with open(os.path.join(self.target_path, 'meta.json'), 'w') as mj:
+                json.dump(self.meta, mj)
+            yield from session.close()
+
 
 def main():
     if os.getuid() != 0:
@@ -164,8 +188,11 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--target", help="domain of the page to be cloned", required=True)
     args = parser.parse_args()
-    cloner = Cloner(args.target)
-    loop.run_until_complete(cloner.run())
+    try:
+        cloner = Cloner(args.target)
+        loop.run_until_complete(cloner.run())
+    except KeyboardInterrupt:
+        pass
 
 
 if __name__ == '__main__':

--- a/snare.py
+++ b/snare.py
@@ -442,7 +442,7 @@ if __name__ == '__main__':
         print("--page-dir: {0} does not exist".format(args.page_dir))
         exit()
     if not os.path.exists('/opt/snare/pages/' + args.page_dir + "/" + args.index_page):
-        print('can\'t crate meta tag')
+        print('can\'t create meta tag')
     else:
         add_meta_tag(args.page_dir, args.index_page)
     loop = asyncio.get_event_loop()

--- a/snare.py
+++ b/snare.py
@@ -443,6 +443,7 @@ if __name__ == '__main__':
     if not os.path.exists(os.path.join(base_page_path,args.page_dir)):
         print("--page-dir: {0} does not exist".format(args.page_dir))
         exit()
+    args.index_page = os.path.join("/",args.index_page)
     with open(os.path.join(base_page_path,args.page_dir, 'meta.json')) as meta:
         meta_info = json.load(meta)
     if not os.path.exists(os.path.join(base_page_path,args.page_dir,os.path.join(meta_info[args.index_page]['hash']))):

--- a/snare.py
+++ b/snare.py
@@ -223,12 +223,12 @@ class HttpRequestHandler(aiohttp.server.ServerHttpProtocol):
                 file_name = self.meta[requested_name]['hash']
                 content_type = self.meta[requested_name]['content_type']
             except KeyError:
-
                 response = aiohttp.Response(
                     self.writer, status=404, http_version=request.version
                 )
-            path = os.path.normpath(os.path.join(base_path, parsed_url))
-                if os.path.isfile(path) and path.startswith(self.dir):
+            else:
+                path = os.path.join(self.dir, file_name)
+                if os.path.isfile(path):
                     with open(path, 'rb') as fh:
                         content = fh.read()
                     if content_type:

--- a/snare.py
+++ b/snare.py
@@ -27,7 +27,7 @@ import sys
 import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor
-from urllib.parse import parse_qsl
+from urllib.parse import parse_qsl, unquote
 
 import aiohttp
 import git
@@ -220,6 +220,7 @@ class HttpRequestHandler(aiohttp.server.ServerHttpProtocol):
             if requested_name == '/':
                 requested_name = self.run_args.index_page
             try:
+                requested_name = unquote(requested_name)
                 file_name = self.meta[requested_name]['hash']
                 content_type = self.meta[requested_name]['content_type']
             except KeyError:


### PR DESCRIPTION
I implemented new experimental cloner, which clones all the paths from the site. It replaces path and query with hash and stores it in a one directory. Also new cloner stores all metadata in json: source name, hash and content type. Because of the fact, that we get content type from the headers, we don't need to guess it (and make errors). In the future we can store more meta info, if we need it. 

**Why hashes?** 
Because sometimes we need to store path and query, especially when we had link such as foo.com/?p=21 (e.g. wordpress) Some queries quite long, so we can get os error. Hashes allows us store all types of the file. 

**Problems:**
- It gets all the files. All. So, if the site has a lot of pages, it can takes a long time. So we need to restrict cloning depth #39 
- Doesn't work with subdomains. 
- Maybe something else :) 

I tested it on some sites and it worked well, but more testing is required.