### PR TITLE
Replace existing stale cookie

### DIFF
--- a/snare.py
+++ b/snare.py
@@ -234,13 +234,17 @@ class HttpRequestHandler(aiohttp.server.ServerHttpProtocol):
                     self.writer, status=404, http_version=request.version
                 )
         response.add_header('Server', self.run_args.server_header)
+        
         if 'cookies' in data and 'sess_uuid' in data['cookies']:
             previous_sess_uuid = data['cookies']['sess_uuid']
         else:
             previous_sess_uuid = None
-        if previous_sess_uuid is None or not previous_sess_uuid.strip():
-            if 'sess_uuid' in event_result['response']['message']:
-                response.add_header('Set-Cookie', 'sess_uuid='+event_result['response']['message']['sess_uuid'])
+        
+        if 'sess_uuid' in event_result['response']['message']:
+            cur_sess_id = event_result['response']['message']['sess_uuid']
+            if previous_sess_uuid is None or not previous_sess_uuid.strip() or previous_sess_uuid != cur_sess_id:
+                response.add_header('Set-Cookie', 'sess_uuid=' + cur_sess_id)
+        
         if not content_type:
             response.add_header('Content-Type', 'text/plain')
         else:


### PR DESCRIPTION
When we request snare with a random sess_uuid cookie, then tanner generates a new sess_uuid cookie with each request and old cookie doesn't get replaced.
But this fix, old cookie will be replaced with the new one.