### PR TITLE
Cloner level fixes

### DIFF
--- a/clone.py
+++ b/clone.py
@@ -170,14 +170,18 @@ class Cloner(object):
                         if not carved_url.is_absolute():
                             carved_url = self.root.join(carved_url)
                         if carved_url.human_repr() not in self.visited_urls:
-                            await self.new_urls.put(carved_url)
+                            await self.new_urls.put((carved_url,level+1))
 
     async def get_root_host(self):
-        with aiohttp.ClientSession() as session:
-            resp = await session.get(self.root)
-            if resp._url_obj.host != self.root.host:
-                self.moved_root = resp._url_obj
-            resp.close()
+        try:
+            with aiohttp.ClientSession() as session:
+                resp = await session.get(self.root)
+                if resp._url_obj.host != self.root.host:
+                    self.moved_root = resp._url_obj
+                resp.close()
+        except aiohttp.errors.ClientError as err:
+            print("Can\'t connect to target host.")
+            exit(-1)
 
     async def run(self):
         session = aiohttp.ClientSession()


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "./clone.py", line 217, in <module>
    main()
  File "./clone.py", line 211, in main
    loop.run_until_complete(cloner.run())
  File "/usr/lib/python3.5/asyncio/base_events.py", line 387, in
run_until_complete
    return future.result()
  File "/usr/lib/python3.5/asyncio/futures.py", line 274, in result
    raise self._exception
  File "/usr/lib/python3.5/asyncio/tasks.py", line 239, in _step
    result = coro.send(None)
  File "./clone.py", line 186, in run
    await self.get_body(session)
  File "./clone.py", line 136, in get_body
    current_url, level = await self.new_urls.get()
TypeError: 'URL' object is not iterable
```

The problem was in queue: for level checking it stores links in format (URL, level), but css links were pushed not in tuples. Now fixed.

Thanks @nsmfoo for sharing this bug :)