### PR TITLE
add Dockerfile, docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine
+
+# Setup apt
+RUN apk -U --no-cache add \
+               build-base \
+               git \
+               linux-headers \
+               python3 \
+               python3-dev && \ 
+
+# Setup Snare
+    git clone --depth=1 https://github.com/mushorg/snare /opt/snare && \
+    cd /opt/snare/ && \
+    pip3 install --no-cache-dir --upgrade pip setuptools && \
+    pip3 install --no-cache-dir -r requirements.txt && \
+    python3.6 clone.py --target http://example.com && \
+    
+# Clean up
+    apk del --purge \
+            build-base \
+            linux-headers \
+            python3-dev && \
+    rm -rf /root/* && \
+    rm -rf /tmp/* /var/tmp/* && \
+    rm -rf /var/cache/apk/*
+
+# Start snare
+WORKDIR /opt/snare
+CMD /usr/bin/python3.6 /opt/snare/snare.py --no-dorks --auto-update false --host-ip 0.0.0.0 --port 80 --page-dir example.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '2.3'
+
+networks:
+  snare_local:
+
+services:
+
+# Snare service
+  snare:
+    build: .
+    container_name: snare
+    restart: always
+    stop_signal: SIGKILL
+    tty: true
+    networks:
+     - snare_local
+    ports:
+     - "80:80"
+    image: "mushorg/snare:latest"


### PR DESCRIPTION
Build with:
`docker-compose build`

Run with:
`docker-compose up`

Cloning from remote to avoid including unnecessary files and keeping the resulting image slim. Opted against Docker multi-stage build which resulted in slightly larger image size.