### PR TITLE
Fix attack requests from snare-develop

### DIFF
--- a/snare/server.py
+++ b/snare/server.py
@@ -37,7 +37,7 @@ class HttpRequestHandler():
             self.logger.error('Error submitting slurp: %s', e)
 
     async def handle_request(self, request):
-        self.logger.info('Request path: {0}'.format(request.path))
+        self.logger.info('Request path: {0}'.format(request.path_qs))
         data = self.tanner_handler.create_data(request, 200)
         if request.method == 'POST':
             post_data = await request.post()
@@ -51,10 +51,10 @@ class HttpRequestHandler():
 
         # Log the event to slurp service if enabled
         if self.run_args.slurp_enabled:
-            await self.submit_slurp(request.path)
+            await self.submit_slurp(request.path_qs)
 
         content, content_type, headers, status_code = await self.tanner_handler.parse_tanner_response(
-            request.path, event_result['response']['message']['detection'])
+            request.path_qs, event_result['response']['message']['detection'])
 
         response_headers = multidict.CIMultiDict()
 

--- a/snare/tanner_handler.py
+++ b/snare/tanner_handler.py
@@ -37,7 +37,7 @@ class TannerHandler():
             header = {key: value for (key, value) in request.headers.items()}
             data['method'] = request.method
             data['headers'] = header
-            data['path'] = request.path
+            data['path'] = request.path_qs
             if ('Cookie' in header):
                 data['cookies'] = {
                     cookie.split('=')[0]: cookie.split('=')[1] for cookie in header['Cookie'].split(';')

--- a/snare/tests/test_create_data.py
+++ b/snare/tests/test_create_data.py
@@ -45,7 +45,7 @@ class TestCreateData(unittest.TestCase):
         self.response_status = "test_status"
         self.data = None
         self.expected_data = {
-            'method': 'POST', 'path': '/',
+            'method': 'POST', 'path': 'http://test_url/',
                               'headers': {'Host': 'test_host', 'status': 200,
                                           'Cookie': 'sess_uuid=prev_test_uuid; test_cookie=test'},
                               'uuid': '9c10172f-7ce2-4fb4-b1c6-abc70141db56',

--- a/snare/tests/test_handle_request.py
+++ b/snare/tests/test_handle_request.py
@@ -84,14 +84,14 @@ class TestHandleRequest(unittest.TestCase):
         async def test():
             await self.handler.handle_request(self.request)
         self.loop.run_until_complete(test())
-        self.handler.submit_slurp.assert_called_with(self.request.path)
+        self.handler.submit_slurp.assert_called_with(self.request.path_qs)
 
     def test_parse_response(self):
 
         async def test():
             await self.handler.handle_request(self.request)
         self.loop.run_until_complete(test())
-        self.handler.tanner_handler.parse_tanner_response.assert_called_with(self.request.path, {'type': 1})
+        self.handler.tanner_handler.parse_tanner_response.assert_called_with(self.request.path_qs, {'type': 1})
 
     def tearDown(self):
         shutil.rmtree(self.main_page_path)


### PR DESCRIPTION
This PR will change `path` to `path_qs` which will fix the detection of attacks from snare-develop.
- Current requests : `https://www.example.com/games?foo=bar` are sent to tanner as `https://www.example.com/games`.
- After fix: `https://www.example.com/games?foo=bar`  will be sent as `https://www.example.com/games?foo=bar` 