### PR TITLE
fix 'status_404' with request containing prefixed protocol

### DIFF
--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -33,9 +33,10 @@ class Cloner(object):
     def add_scheme(url):
         if yarl.URL(url).scheme:
             new_url = yarl.URL(url)
+            err_url = yarl.URL(url + '/status_404')
         else:
             new_url = yarl.URL('http://' + url)
-        err_url = yarl.URL('http://' + url + '/status_404')
+            err_url = yarl.URL('http://' + url + '/status_404')
         return new_url, err_url
 
     async def process_link(self, url, level, check_host=False):


### PR DESCRIPTION
@t3chn0m4g3 found out that when we clone pages like:
`clone --target http://example.com` and run snare.
We face `status_404` error in snare.
This pr will fix that issue #154 