### PR TITLE
possibility to change default directory, fixes #134

### DIFF
--- a/bin/clone
+++ b/bin/clone
@@ -38,15 +38,26 @@ def main():
     parser.add_argument(
         "--css-validate", help="set whether css validation is required", type=str_to_bool, default=None
     )
+    parser.add_argument("--path", help="path where the clone page will be saved", required=False, default=None)
     args = parser.parse_args()
-    if args.log_path:
-        log_err = args.log_path + "clone.err"
+    if args.path:
+        default_path = os.path.join(args.path, 'snare')
     else:
-        log_err = "/opt/snare/clone.err"
+        default_path = '/opt/snare'
+    if args.log_path:
+        log_err = os.path.join(args.log_path, 'clone.err')
+    else:
+        log_err = os.path.join(default_path, 'clone.err')
+
+    # Creates directory for log files
+    if not os.path.isfile(log_err):
+        if not os.path.exists(os.path.dirname(log_err)):
+            os.makedirs(os.path.dirname(log_err))
+
     logger.Logger.create_clone_logger(log_err, __package__)
     print("Error logs will be stored in {}\n".format(log_err))
     try:
-        cloner = Cloner(args.target, int(args.max_depth), args.css_validate)
+        cloner = Cloner(args.target, int(args.max_depth), args.css_validate, default_path)
         loop.run_until_complete(cloner.get_root_host())
         loop.run_until_complete(cloner.run())
     except KeyboardInterrupt:
@@ -60,6 +71,6 @@ if __name__ == '__main__':
   / /    / /     / / / //  |/ / __/ / /_/ /
  / /___ / /____ / /_/ // /|  / /___/ _, _/
 /_____//______//_____//_/ |_/_____/_/ |_|
-    
+
     """)
     main()

--- a/bin/snare
+++ b/bin/snare
@@ -35,30 +35,29 @@ from snare.utils import snare_helpers
 from snare.utils.snare_helpers import str_to_bool
 
 
-def create_initial_config():
+def create_initial_config(base_path):
     cfg = configparser.ConfigParser()
     cfg['WEB-TOOLS'] = dict(google='', bing='')
-    with open('/opt/snare/snare.cfg', 'w') as configfile:
+    with open(os.path.join(base_path, 'snare.cfg'), 'w') as configfile:
         cfg.write(configfile)
 
-
-def snare_setup():
+def snare_setup(base_path):
     if os.getuid() != 0:
         print('Snare has to be started as root!')
         sys.exit(1)
     # Create folders
-    if not os.path.exists('/opt/snare'):
-        os.mkdir('/opt/snare')
-    if not os.path.exists('/opt/snare/pages'):
-        os.mkdir('/opt/snare/pages')
+    if not os.path.exists(base_path):
+        os.mkdir(base_path)
+    if not os.path.exists(os.path.join(base_path, 'pages')):
+        os.mkdir(os.path.join(base_path, 'pages'))
     # Write pid to pid file
-    with open('/opt/snare/snare.pid', 'wb') as pid_fh:
+    with open(os.path.join(base_path, 'snared.pid'), 'wb') as pid_fh:
         pid_fh.write(str(os.getpid()).encode('utf-8'))
     # Config file
-    if not os.path.exists('/opt/snare/snare.cfg'):
-        create_initial_config()
+    if not os.path.exists(os.path.join(base_path, 'snare.cfg')):
+        create_initial_config(base_path)
     # Read or create the sensor id
-    uuid_file_path = '/opt/snare/snare.uuid'
+    uuid_file_path = os.path.join(base_path, 'snare.uuid')
     if os.path.exists(uuid_file_path):
         with open(uuid_file_path, 'rb') as uuid_fh:
             snare_uuid = uuid_fh.read()
@@ -150,10 +149,15 @@ if __name__ == '__main__':
     parser.add_argument("--server-header", help="set server-header", default='nignx/1.3.8')
     parser.add_argument("--no-dorks", help="disable the use of dorks", type=str_to_bool,  default=True)
     parser.add_argument("--log-dir", help="path to directory of the log file", default='/opt/snare/')
+    parser.add_argument("--path", help="path to the directory of the cloned page", required=False, default=None)
     args = parser.parse_args()
-    base_path = '/opt/snare/'
-    base_page_path = '/opt/snare/pages/'
-    snare_uuid = snare_setup()
+    if not args.path:
+        base_path = '/opt/snare/'
+        base_page_path = '/opt/snare/pages/'
+    else:
+        base_path = os.path.join(args.path, 'snare')
+        base_page_path = os.path.join(base_path, 'pages')
+    snare_uuid = snare_setup(base_path)
     config = configparser.ConfigParser()
     config.read(os.path.join(base_path, args.config))
     log_debug = args.log_dir + "snare.log"
@@ -174,7 +178,7 @@ if __name__ == '__main__':
     if not os.path.exists(os.path.join(full_page_path, 'meta.json')):
         conv = snare_helpers.Converter()
         conv.convert(full_page_path)
-        print("pages was converted. Try to clone again for the better result.")
+        print("pages were converted. Try to clone again for the better result.")
 
     with open(os.path.join(full_page_path, 'meta.json')) as meta:
         meta_info = json.load(meta)
@@ -182,7 +186,7 @@ if __name__ == '__main__':
                                        os.path.join(meta_info[args.index_page]['hash']))):
         print('can\'t create meta tag')
     else:
-        snare_helpers.add_meta_tag(args.page_dir, meta_info[args.index_page]['hash'], config)
+        snare_helpers.add_meta_tag(args.page_dir, meta_info[args.index_page]['hash'], config, base_path)
     loop = asyncio.get_event_loop()
     loop.run_until_complete(check_tanner())
 

--- a/bin/snare
+++ b/bin/snare
@@ -51,7 +51,7 @@ def snare_setup(base_path):
     if not os.path.exists(os.path.join(base_path, 'pages')):
         os.mkdir(os.path.join(base_path, 'pages'))
     # Write pid to pid file
-    with open(os.path.join(base_path, 'snared.pid'), 'wb') as pid_fh:
+    with open(os.path.join(base_path, 'snare.pid'), 'wb') as pid_fh:
         pid_fh.write(str(os.getpid()).encode('utf-8'))
     # Config file
     if not os.path.exists(os.path.join(base_path, 'snare.cfg')):

--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -14,7 +14,7 @@ from bs4 import BeautifulSoup
 
 class Cloner(object):
     def __init__(self, root, max_depth, css_validate, default_path):
-        self.visited_urls = []#
+        self.visited_urls = []
         self.root, self.error_page = self.add_scheme(root)
         self.max_depth = max_depth
         self.moved_root = None

--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -13,17 +13,17 @@ from bs4 import BeautifulSoup
 
 
 class Cloner(object):
-    def __init__(self, root, max_depth, css_validate):
-        self.visited_urls = []
+    def __init__(self, root, max_depth, css_validate, default_path):
+        self.visited_urls = []#
         self.root, self.error_page = self.add_scheme(root)
         self.max_depth = max_depth
         self.moved_root = None
+        self.default_path = default_path
         if len(self.root.host) < 4:
             sys.exit('invalid taget {}'.format(self.root.host))
-        self.target_path = '/opt/snare/pages/{}'.format(self.root.host)
-
+        self.target_path = self.default_path + '/pages/{}'.format(self.root.host)
         if not os.path.exists(self.target_path):
-            os.mkdir(self.target_path)
+            os.makedirs(self.target_path)
         self.css_validate = css_validate
         self.new_urls = Queue()
         self.meta = {}

--- a/snare/tests/test_add_meta_tag.py
+++ b/snare/tests/test_add_meta_tag.py
@@ -21,7 +21,8 @@ class TestAddMetaTag(unittest.TestCase):
     def test_add_meta_tag(self):
         config = configparser.ConfigParser()
         config['WEB-TOOLS'] = dict(google='test google content', bing='test bing content')
-        add_meta_tag(self.page_dir, self.index_page, config)
+        default_path = '/opt/snare'
+        add_meta_tag(self.page_dir, self.index_page, config, default_path)
         with open(os.path.join(self.main_page_path, 'index.html')) as main:
             main_page = main.read()
         soup = BeautifulSoup(main_page, 'html.parser')

--- a/snare/utils/snare_helpers.py
+++ b/snare/utils/snare_helpers.py
@@ -51,14 +51,14 @@ class Converter:
             json.dump(self.meta, mj)
 
 
-def add_meta_tag(page_dir, index_page, config):
+def add_meta_tag(page_dir, index_page, config, base_path):
     google_content = config['WEB-TOOLS']['google']
     bing_content = config['WEB-TOOLS']['bing']
 
     if not google_content and not bing_content:
         return
 
-    main_page_path = os.path.join('/opt/snare/pages/', page_dir, index_page)
+    main_page_path = os.path.join(os.path.join(base_path,'pages'), page_dir, index_page)
     with open(main_page_path) as main:
         main_page = main.read()
     soup = BeautifulSoup(main_page, 'html.parser')


### PR DESCRIPTION
fixes #134 
This pull request adds the possibility to change the default directory. The default directory is currently set to `opt/snare` . At times user may want to change the default path, this PR gives them the possibility to change their default path by using a `--path <directory_path>` argument.

- Cloner can now take a `--path` argument, hence user can specify where they want to store their cloned webpage. If no `--path` argument is provided, cloner saves the cloned files in the default path, `opt/snare` .

- Snare config, uuid, pid is now saved into the path specified by the user else is stored in the default path, `/opt/snare` .

- While running Snare, user can specify their directory using `--path` argument .

- `add_meta_tag` in `test_add_meta_tag.py` is updated since `add_meta_tag` now takes 4 arguments instead of 3 (`default_path` is being passed) .

**Example :** 
1. `sudo clone --target http://example.com --path /root/file1` will save all the cloned web page in `root/file1/snare/pages/example.com`
2. snare config, pid and uid files will be saved in `root/file1/snare`
3. log path if specified will be saved in the specified path else will follow the path directory, here `root/file1/snare/clone.err` 
4. `sudo snare --page-dir example.com --path /root/file1` will retrieve the web pages from `root/file1/snare/pages/example.com`

Checklist : 

- [x] My branch is up-to-date with the Upstream master branch.
- [x] I have gone through the code base carefully before making this PR. 