### PR TITLE
fix errors when building images with the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apk -U --no-cache add \
                linux-headers \
                python3 \
                python3-dev && \
-
 # Setup Snare 
     git clone --depth=1 https://github.com/mushorg/snare /opt/snare && \
     cd /opt/snare/ && \
@@ -17,7 +16,6 @@ RUN apk -U --no-cache add \
     cd / && \
     rm -rf /opt/snare && \
     clone --target http://example.com && \
-
 # Clean up
     apk del --purge \
             build-base \
@@ -26,6 +24,5 @@ RUN apk -U --no-cache add \
     rm -rf /root/* && \
     rm -rf /tmp/* /var/tmp/* && \
     rm -rf /var/cache/apk/*
-
 # Start snare
 CMD snare --no-dorks true --auto-update false --host-ip 0.0.0.0 --port 8080 --page-dir example.com


### PR DESCRIPTION
The backslash indicates a new command and the empty lines throw errors when you build the image. Delete the empty lines. This should fix some errors.