### PR TITLE
test tanner-parse-response

### DIFF
--- a/snare/tests/test_parse_tanner_response.py
+++ b/snare/tests/test_parse_tanner_response.py
@@ -73,6 +73,8 @@ class TestParseTannerResponse(unittest.TestCase):
         expected_result = [self.expected_content, self.content_type, {}, 200]
         self.assertCountEqual(real_result, expected_result)
 
+    def test_parse_type_two_with_headers(self):
+
         self.detection = {
             "type": 2,
             "payload": {

--- a/snare/tests/test_parse_tanner_response.py
+++ b/snare/tests/test_parse_tanner_response.py
@@ -40,6 +40,7 @@ class TestParseTannerResponse(unittest.TestCase):
         self.detection = None
         self.expected_content = None
         self.call_content = None
+        self.expected_header = None
 
     def test_parse_type_one(self):
         self.detection = {"type": 1}
@@ -85,15 +86,17 @@ class TestParseTannerResponse(unittest.TestCase):
                 }
             }
         }
+        self.expected_content = b'test.png'
+        self.content_type = 'image/png'
+        self.expected_header = {"content-type": "multipart/form-data"}
 
         async def test():
             (self.res1, self.res2,
              self.res3, self.res4) = await self.handler.parse_tanner_response(self.requested_name, self.detection)
 
         self.loop.run_until_complete(test())
-        expected_header = {"content-type": "multipart/form-data"}
         real_result = [self.res1, self.res2, self.res3, self.res4]
-        expected_result = [b'test.png', 'image/png', expected_header, 200]
+        expected_result = [self.expected_content, self.content_type, self.expected_header, 200]
         self.assertCountEqual(real_result, expected_result)
 
     def test_parse_type_three(self):

--- a/snare/tests/test_parse_tanner_response.py
+++ b/snare/tests/test_parse_tanner_response.py
@@ -73,6 +73,27 @@ class TestParseTannerResponse(unittest.TestCase):
         expected_result = [self.expected_content, self.content_type, {}, 200]
         self.assertCountEqual(real_result, expected_result)
 
+        self.detection = {
+            "type": 2,
+            "payload": {
+                "page": "",
+                "value": "test.png",
+                "headers": {
+                    "content-type": "multipart/form-data"
+                }
+            }
+        }
+
+        async def test():
+            (self.res1, self.res2,
+             self.res3, self.res4) = await self.handler.parse_tanner_response(self.requested_name, self.detection)
+
+        self.loop.run_until_complete(test())
+        expected_header = {"content-type": "multipart/form-data"}
+        real_result = [self.res1, self.res2, self.res3, self.res4]
+        expected_result = [b'test.png', 'image/png', expected_header, 200]
+        self.assertCountEqual(real_result, expected_result)
+
     def test_parse_type_three(self):
         self.detection = {
             "type": 3,

--- a/snare/tests/test_submit_data.py
+++ b/snare/tests/test_submit_data.py
@@ -6,13 +6,10 @@ import os
 import json
 import yarl
 import aiohttp
-import logging
-from unittest import mock
+from json import JSONDecodeError
 from snare.utils.asyncmock import AsyncMock
 from snare.tanner_handler import TannerHandler
 from snare.utils.page_path_generator import generate_unique_path
-
-logger = logging.getLogger(__name__)
 
 
 class TestSubmitData(unittest.TestCase):
@@ -70,19 +67,14 @@ class TestSubmitData(unittest.TestCase):
         self.assertEqual(self.result, dict(detection={'type': 1}, sess_uuid="test_uuid"))
 
     def test_submit_data_error(self):
-
-        async def mock_json_decode_error(data):
-            logger.error('Error submitting data: JSONDecodeError {}'.format(data))
-
-        self.handler = mock.Mock()
-        self.handler.submit_data = mock_json_decode_error
+        aiohttp.ClientResponse.json = AsyncMock(side_effect=JSONDecodeError('ERROR', '', 0))
 
         async def test():
             self.result = await self.handler.submit_data(self.data)
 
         with self.assertLogs(level='ERROR') as log:
             self.loop.run_until_complete(test())
-            self.assertIn('Error submitting data: JSONDecodeError {}'.format(self.data), log.output[0])
+            self.assertIn('Error submitting data: ERROR: line 1 column 1 (char 0) {}'.format(self.data), log.output[0])
 
     def test_event_result_exception(self):
         aiohttp.ClientResponse.json = AsyncMock(side_effect=Exception())


### PR DESCRIPTION
Added test for `parse_tanner_response`.
Increased test coverage of `tanner_handler.py`  to 92%.
Refs - #187 