### PR TITLE
clear query in url while cloning

### DIFF
--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -102,6 +102,8 @@ class Cloner(object):
 
     def _make_filename(self, url):
         host = url.host
+        # clear query
+        url = url.with_query(None)
         if url.is_absolute():
             file_name = url.relative().human_repr()
         else:


### PR DESCRIPTION
## Description
Fix for #182.
Cloner preserve query string in url before creating `filename`, while snare remove query string before serving content. This inconsistency leads to 404 response.
## How to reproduce
1. `clone --target http://readms.net --max-depth 1` 
2. `sudo snare --port 8080 --page-dir readms.net`
3. Visit http://localhost:8080/
## Solution
Remove query string in url before creating `filename` 