### PR TITLE
check url with query when detection = 1

### DIFF
--- a/snare/tanner_handler.py
+++ b/snare/tanner_handler.py
@@ -78,7 +78,7 @@ class TannerHandler():
             if query_start != -1:
                 possible_requests.append(requested_name[:query_start])
 
-            found = False
+            file_name = None
             for requested_name in possible_requests:
                 if requested_name == '/':
                     requested_name = self.run_args.index_page
@@ -91,9 +91,8 @@ class TannerHandler():
                 except KeyError:
                     pass
                 else:
-                    found = True
                     break
-            if not found:
+            if not file_name:
                 status_code = 404
             else:
                 path = os.path.join(self.dir, file_name)

--- a/snare/tanner_handler.py
+++ b/snare/tanner_handler.py
@@ -73,18 +73,27 @@ class TannerHandler():
         requested_name = p.sub('/', requested_name)
 
         if detection['type'] == 1:
+            possible_requests = [requested_name]
             query_start = requested_name.find('?')
             if query_start != -1:
-                requested_name = requested_name[:query_start]
-            if requested_name == '/':
-                requested_name = self.run_args.index_page
-            try:
+                possible_requests.append(requested_name[:query_start])
+
+            found = False
+            for requested_name in possible_requests:
+                if requested_name == '/':
+                    requested_name = self.run_args.index_page
                 if requested_name[-1] == '/':
                     requested_name = requested_name[:-1]
                 requested_name = unquote(requested_name)
-                file_name = self.meta[requested_name]['hash']
-                content_type = self.meta[requested_name]['content_type']
-            except KeyError:
+                try:
+                    file_name = self.meta[requested_name]['hash']
+                    content_type = self.meta[requested_name]['content_type']
+                except KeyError:
+                    pass
+                else:
+                    found = True
+                    break
+            if not found:
                 status_code = 404
             else:
                 path = os.path.join(self.dir, file_name)


### PR DESCRIPTION
Fix for #196. 
Check url with query when `detection = 1`. This allows serving cloned content with query in url. 
