### PR TITLE
add server header in middleware

### DIFF
--- a/snare/middlewares.py
+++ b/snare/middlewares.py
@@ -20,10 +20,12 @@ class SnareMiddleware():
         async def error_middleware(request, handler):
             try:
                 response = await handler(request)
-                override = overrides.get(response.status)
+                status = response.status
+                override = overrides.get(status)
                 if override:
                     response = await override(request)
                     response.headers['Server'] = self.server_header
+                    response.set_status(status)
                     return response
                 return response
             except web.HTTPException as ex:

--- a/snare/middlewares.py
+++ b/snare/middlewares.py
@@ -4,8 +4,9 @@ from aiohttp import web
 
 class SnareMiddleware():
 
-    def __init__(self, file_name):
+    def __init__(self, file_name, server_header):
         self.error_404 = file_name
+        self.server_header = server_header
 
     async def handle_404(self, request):
         return aiohttp_jinja2.render_template(self.error_404, request, {})
@@ -21,7 +22,9 @@ class SnareMiddleware():
                 response = await handler(request)
                 override = overrides.get(response.status)
                 if override:
-                    return await override(request)
+                    response = await override(request)
+                    response.headers['Server'] = self.server_header
+                    return response
                 return response
             except web.HTTPException as ex:
                 override = overrides.get(ex.status)

--- a/snare/server.py
+++ b/snare/server.py
@@ -88,7 +88,10 @@ class HttpRequestHandler():
         aiohttp_jinja2.setup(
             app, loader=jinja2.FileSystemLoader(self.dir)
         )
-        middleware = SnareMiddleware(self.meta['/status_404']['hash'])
+        middleware = SnareMiddleware(
+            self.meta['/status_404']['hash'],
+            self.run_args.server_header
+        )
         middleware.setup_middlewares(app)
 
         self.runner = web.AppRunner(app)


### PR DESCRIPTION
Fix for #7 
## Steps to reproduce
1. `sudo clone --target http://example.com`
2. `sudo snare --port 8080 --page-dir example.com`
3. `curl --head http://localhost:8080/notfound`. Response:
```
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
Content-Length: 1237
Date: Mon, 01 Apr 2019 16:49:00 GMT
Server: Python/3.6 aiohttp/3.4.4
```
Server header above is not changed to default `nginx` 