### PR TITLE
Fix KeyError

### DIFF
--- a/snare/server.py
+++ b/snare/server.py
@@ -89,7 +89,7 @@ class HttpRequestHandler():
             app, loader=jinja2.FileSystemLoader(self.dir)
         )
         middleware = SnareMiddleware(
-            self.meta['/status_404']['hash'],
+            self.meta['/index.html']['hash'],
             self.run_args.server_header
         )
         middleware.setup_middlewares(app)


### PR DESCRIPTION
Fixes #201 

There was no `hash` key in the `/status_404`. Instead, that key is present in `/index.html`

```
{'/index.html': {'hash': 'd1546d731a9f30cc80127d57142a482b', 'content_type': 'text/html'}, '/status_404': {}}
```

So I fixed that and now snare starts properly.