### PR TITLE
Remove version restriction to prevent gitdb error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ aiohttp==3.4.4
 aiohttp_jinja2==1.1.0
 beautifulsoup4==4.6.3
 cssutils==1.0.2
-gitpython==2.1.11
+gitpython==3.1.0
 pycodestyle==2.4.0


### PR DESCRIPTION
When we try to do `sudo docker-compose up` the container resulted in the following error:

```
Creating snare ... done
Attaching to snare
snare    | Traceback (most recent call last):
snare    |   File "/usr/local/bin/snare", line 4, in <module>
snare    |     __import__('pkg_resources').run_script('Snare==0.3.0', 'snare')
snare    |   File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 667, in run_script
snare    |     self.require(requires)[0].run_script(script_name, ns)
snare    |   File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 1470, in run_script
snare    |     exec(script_code, namespace, namespace)
snare    |   File "/usr/local/lib/python3.6/site-packages/Snare-0.3.0-py3.6.egg/EGG-INFO/scripts/snare", line 29, in <module>
snare    |   File "/usr/local/lib/python3.6/site-packages/git/__init__.py", line 38, in <module>
snare    |     from git.exc import *                       # @NoMove @IgnorePep8
snare    |   File "/usr/local/lib/python3.6/site-packages/git/exc.py", line 9, in <module>
snare    |     from git.compat import UnicodeMixin, safe_decode, string_types
snare    |   File "/usr/local/lib/python3.6/site-packages/git/compat.py", line 16, in <module>
snare    |     from gitdb.utils.compat import (
snare    | ModuleNotFoundError: No module named 'gitdb.utils.compat'
```
But if we remove that version restriction the `docker-compose up`  command runs succesfully. 