### PR TITLE
Allow specifying a cloner target with path/qs

### DIFF
--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -32,14 +32,10 @@ class Cloner(object):
 
     @staticmethod
     def add_scheme(url):
-        if url[-1] == '/':
-            url = url.strip('/')
-        if yarl.URL(url).scheme:
-            new_url = yarl.URL(url)
-            err_url = yarl.URL(url + '/status_404')
-        else:
-            new_url = yarl.URL('http://' + url)
-            err_url = yarl.URL('http://' + url + '/status_404')
+        new_url = yarl.URL(url)
+        if not new_url.scheme:
+            new_url = new_url.with_scheme('http')
+        err_url = new_url.with_path('/status_404').with_query(None).with_fragment(None)
         return new_url, err_url
 
     async def process_link(self, url, level, check_host=False):

--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -34,7 +34,7 @@ class Cloner(object):
     def add_scheme(url):
         new_url = yarl.URL(url)
         if not new_url.scheme:
-            new_url = new_url.with_scheme('http')
+            new_url = yarl.URL('http://' + url)
         err_url = new_url.with_path('/status_404').with_query(None).with_fragment(None)
         return new_url, err_url
 


### PR DESCRIPTION
Cloner can now use a starting page requiring both a path and a query string