### PR TITLE
Clone and serve headers

### DIFF
--- a/bin/snare
+++ b/bin/snare
@@ -145,7 +145,7 @@ if __name__ == '__main__':
     parser.add_argument("--config", help="snare config file", default='snare.cfg')
     parser.add_argument("--auto-update", help="auto update SNARE if new version available ", default=True)
     parser.add_argument("--update-timeout", help="update snare every timeout ", default='24H')
-    parser.add_argument("--server-header", help="set server-header", default='nginx/1.3.8')
+    parser.add_argument("--server-header", help="set server-header", default=None)
     parser.add_argument("--no-dorks", help="disable the use of dorks", type=str_to_bool,  default=True)
     parser.add_argument("--log-dir", help="path to directory of the log file", default='/opt/snare/')
     args = parser.parse_args()

--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -43,11 +43,16 @@ class Cloner(object):
 
     @staticmethod
     def get_headers(response):
-        # TODO probably need more...
         ignored_headers_lowercase = [
-            "connection",
-            "content-length",
-            "content-type",
+            'age',
+            'cache-control',
+            'connection',
+            'content-encoding',
+            'content-length',
+            'date',
+            'etag',
+            'expires',
+            'x-cache',
         ]
 
         headers = []

--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -157,22 +157,21 @@ class Cloner(object):
                 # TODO might not be needed anymore if we can rely on the header
                 content_type = response.content_type
                 data = await response.read()
-
             except (aiohttp.ClientError, asyncio.TimeoutError) as client_error:
                 self.logger.error(client_error)
             else:
                 await response.release()
+
             if data is not None:
                 self.meta[file_name]['hash'] = hash_name
                 self.meta[file_name]['headers'] = headers
                 self.meta[file_name]['content_type'] = content_type
                 self.counter = self.counter + 1
+
                 if content_type == 'text/html':
                     soup = await self.replace_links(data, level)
                     data = str(soup).encode()
-                with open(os.path.join(self.target_path, hash_name), 'wb') as index_fh:
-                    index_fh.write(data)
-                if content_type == 'text/css':
+                elif content_type == 'text/css':
                     css = cssutils.parseString(data, validate=self.css_validate)
                     for carved_url in cssutils.getUrls(css):
                         if carved_url.startswith('data'):
@@ -182,6 +181,9 @@ class Cloner(object):
                             carved_url = self.root.join(carved_url)
                         if carved_url.human_repr() not in self.visited_urls:
                             await self.new_urls.put((carved_url, level + 1))
+
+                with open(os.path.join(self.target_path, hash_name), 'wb') as index_fh:
+                    index_fh.write(data)
 
     async def get_root_host(self):
         try:

--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -41,6 +41,21 @@ class Cloner(object):
         err_url = new_url.with_path('/status_404').with_query(None).with_fragment(None)
         return new_url, err_url
 
+    @staticmethod
+    def get_headers(response):
+        # TODO probably need more...
+        ignored_headers_lowercase = [
+            "connection",
+            "content-length",
+            "content-type",
+        ]
+
+        headers = []
+        for key, value in response.headers.items():
+            if key.lower() not in ignored_headers_lowercase:
+                headers.append({key: value})
+        return headers
+
     async def process_link(self, url, level, check_host=False):
         try:
             url = yarl.URL(url)
@@ -133,6 +148,8 @@ class Cloner(object):
             content_type = None
             try:
                 response = await session.get(current_url, headers={'Accept': 'text/html'}, timeout=10.0)
+                headers = self.get_headers(response)
+                # TODO might not be needed anymore if we can rely on the header
                 content_type = response.content_type
                 data = await response.read()
 
@@ -142,6 +159,7 @@ class Cloner(object):
                 await response.release()
             if data is not None:
                 self.meta[file_name]['hash'] = hash_name
+                self.meta[file_name]['headers'] = headers
                 self.meta[file_name]['content_type'] = content_type
                 self.counter = self.counter + 1
                 if content_type == 'text/html':

--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -154,7 +154,6 @@ class Cloner(object):
             try:
                 response = await session.get(current_url, headers={'Accept': 'text/html'}, timeout=10.0)
                 headers = self.get_headers(response)
-                # TODO might not be needed anymore if we can rely on the header
                 content_type = response.content_type
                 data = await response.read()
             except (aiohttp.ClientError, asyncio.TimeoutError) as client_error:
@@ -165,7 +164,6 @@ class Cloner(object):
             if data is not None:
                 self.meta[file_name]['hash'] = hash_name
                 self.meta[file_name]['headers'] = headers
-                self.meta[file_name]['content_type'] = content_type
                 self.counter = self.counter + 1
 
                 if content_type == 'text/html':

--- a/snare/middlewares.py
+++ b/snare/middlewares.py
@@ -5,7 +5,10 @@ from aiohttp import web
 
 class SnareMiddleware():
 
-    def __init__(self, headers, error_404, error_500=None, server_header=None):
+    def __init__(self, error_404, error_500=None, headers=[], server_header=''):
+        self.error_404 = error_404
+        self.error_500 = error_500 if error_500 else '500.html'
+
         self.headers = multidict.CIMultiDict()
         for header in headers:
             for key, value in header.items():
@@ -13,9 +16,6 @@ class SnareMiddleware():
 
         if server_header:
             self.headers['Server'] = server_header
-
-        self.error_404 = error_404
-        self.error_500 = error_500 if error_500 else '500.html'
 
     async def handle_404(self, request):
         return aiohttp_jinja2.render_template(self.error_404, request, {})

--- a/snare/middlewares.py
+++ b/snare/middlewares.py
@@ -4,7 +4,7 @@ from aiohttp import web
 
 class SnareMiddleware():
 
-    def __init__(self, file_name, server_header):
+    def __init__(self, file_name, server_header=None):
         self.error_404 = file_name
         self.server_header = server_header
 
@@ -24,7 +24,8 @@ class SnareMiddleware():
                 override = overrides.get(status)
                 if override:
                     response = await override(request)
-                    response.headers['Server'] = self.server_header
+                    if self.server_header:
+                        response.headers['Server'] = self.server_header
                     response.set_status(status)
                     return response
                 return response

--- a/snare/middlewares.py
+++ b/snare/middlewares.py
@@ -1,18 +1,27 @@
 import aiohttp_jinja2
+import multidict
 from aiohttp import web
 
 
 class SnareMiddleware():
 
-    def __init__(self, file_name, server_header=None):
-        self.error_404 = file_name
-        self.server_header = server_header
+    def __init__(self, headers, error_404, error_500=None, server_header=None):
+        self.headers = multidict.CIMultiDict()
+        for header in headers:
+            for key, value in header.items():
+                self.headers.add(key, value)
+
+        if server_header:
+            self.headers['Server'] = server_header
+
+        self.error_404 = error_404
+        self.error_500 = error_500 if error_500 else '500.html'
 
     async def handle_404(self, request):
         return aiohttp_jinja2.render_template(self.error_404, request, {})
 
     async def handle_500(self, request):
-        return aiohttp_jinja2.render_template('500.html', request, {})
+        return aiohttp_jinja2.render_template(self.error_500, request, {})
 
     def create_error_middleware(self, overrides):
 
@@ -24,8 +33,7 @@ class SnareMiddleware():
                 override = overrides.get(status)
                 if override:
                     response = await override(request)
-                    if self.server_header:
-                        response.headers['Server'] = self.server_header
+                    response.headers.update(self.headers)
                     response.set_status(status)
                     return response
                 return response
@@ -40,6 +48,6 @@ class SnareMiddleware():
     def setup_middlewares(self, app):
         error_middleware = self.create_error_middleware({
             404: self.handle_404,
-            500: self.handle_500
+            500: self.handle_500,
         })
         app.middlewares.append(error_middleware)

--- a/snare/server.py
+++ b/snare/server.py
@@ -52,7 +52,7 @@ class HttpRequestHandler():
         if self.run_args.slurp_enabled:
             await self.submit_slurp(request.path_qs)
 
-        content, content_type, headers, status_code = await self.tanner_handler.parse_tanner_response(
+        content, headers, status_code = await self.tanner_handler.parse_tanner_response(
             request.path_qs, event_result['response']['message']['detection'])
 
         if self.run_args.server_header:
@@ -68,11 +68,7 @@ class HttpRequestHandler():
             if previous_sess_uuid is None or not previous_sess_uuid.strip() or previous_sess_uuid != cur_sess_id:
                 headers.add('Set-Cookie', 'sess_uuid=' + cur_sess_id)
 
-        if not content_type:
-            content_type = 'text/plain'
-
-        response = web.Response(body=content, status=status_code, headers=headers, content_type=content_type)
-        return response
+        return web.Response(body=content, status=status_code, headers=headers)
 
     async def start(self):
         app = web.Application()

--- a/snare/server.py
+++ b/snare/server.py
@@ -77,8 +77,9 @@ class HttpRequestHandler():
             app, loader=jinja2.FileSystemLoader(self.dir)
         )
         middleware = SnareMiddleware(
-            self.meta['/status_404']['hash'],
-            self.run_args.server_header
+            headers=self.meta['/status_404']['headers'],
+            error_404=self.meta['/status_404']['hash'],
+            server_header=self.run_args.server_header
         )
         middleware.setup_middlewares(app)
 

--- a/snare/server.py
+++ b/snare/server.py
@@ -77,8 +77,8 @@ class HttpRequestHandler():
             app, loader=jinja2.FileSystemLoader(self.dir)
         )
         middleware = SnareMiddleware(
-            headers=self.meta['/status_404']['headers'],
-            error_404=self.meta['/status_404']['hash'],
+            error_404=self.meta['/status_404'].get('hash'),
+            headers=self.meta['/status_404'].get('headers', []),
             server_header=self.run_args.server_header
         )
         middleware.setup_middlewares(app)

--- a/snare/tanner_handler.py
+++ b/snare/tanner_handler.py
@@ -96,9 +96,10 @@ class TannerHandler():
                     for header in self.meta[requested_name].get('headers', []):
                         for key, value in header.items():
                             headers.add(key, value)
-                    if 'content_type' in self.meta[requested_name]:
-                        # overwrite headers with legacy content-type if present
-                        headers['Content-Type'] = self.meta[requested_name]['content_type']
+                    # overwrite headers with legacy content-type if present and not none
+                    content_type = self.meta[requested_name].get('content_type')
+                    if content_type:
+                        headers['Content-Type'] = content_type
                 except KeyError:
                     pass
                 else:
@@ -122,9 +123,10 @@ class TannerHandler():
                     for header in self.meta[payload_content['page']].get('headers', []):
                         for key, value in header.items():
                             headers.add(key, value)
-                    if 'content_type' in self.meta[payload_content['page']]:
-                        # overwrite headers with legacy content-type if present
-                        headers['Content-Type'] = self.meta[payload_content['page']]['content_type']
+                    # overwrite headers with legacy content-type if present and not none
+                    content_type = self.meta[payload_content['page']].get('content_type')
+                    if content_type:
+                        headers['Content-Type'] = content_type
                     page_path = os.path.join(self.dir, file_name)
                     with open(page_path, encoding='utf-8') as p:
                         content = p.read()
@@ -138,7 +140,9 @@ class TannerHandler():
                 soup.body.append(script_tag)
                 content = str(soup).encode()
             else:
-                headers['Content-Type'] = mimetypes.guess_type(payload_content['value'])[0]
+                content_type = mimetypes.guess_type(payload_content['value'])[0]
+                if content_type:
+                    headers['Content-Type'] = content_type
                 content = payload_content['value'].encode('utf-8')
 
             if 'headers' in payload_content:

--- a/snare/tanner_handler.py
+++ b/snare/tanner_handler.py
@@ -93,7 +93,7 @@ class TannerHandler():
                 requested_name = unquote(requested_name)
                 try:
                     file_name = self.meta[requested_name]['hash']
-                    for header in self.meta[requested_name]['headers']:
+                    for header in self.meta[requested_name].get('headers', []):
                         for key, value in header.items():
                             headers.add(key, value)
                     if 'content_type' in self.meta[requested_name]:
@@ -119,7 +119,7 @@ class TannerHandler():
             if payload_content['page']:
                 try:
                     file_name = self.meta[payload_content['page']]['hash']
-                    for header in self.meta[payload_content['page']]['headers']:
+                    for header in self.meta[payload_content['page']].get('headers', []):
                         for key, value in header.items():
                             headers.add(key, value)
                     if 'content_type' in self.meta[payload_content['page']]:

--- a/snare/tanner_handler.py
+++ b/snare/tanner_handler.py
@@ -139,9 +139,10 @@ class TannerHandler():
                 content = payload_content['value'].encode('utf-8')
 
             if 'headers' in payload_content:
-                headers.update(payload_content['headers'])  # overwrite local headers with the tanner-provided ones
-                #headers.extend(payload_content['headers'])  # keep both headers with same name (undesired behavior)
-        else:
+                # overwrite local headers with the tanner-provided ones
+                headers.update(payload_content['headers'])
+
+        else:  # type 3
             payload_content = detection['payload']
             status_code = payload_content['status_code']
 

--- a/snare/tests/test_cloner_get_body.py
+++ b/snare/tests/test_cloner_get_body.py
@@ -49,8 +49,16 @@ class TestGetBody(unittest.TestCase):
         self.filename, self.hashname = self.handler._make_filename(yarl.URL(self.root))
         self.expected_content = '<html><body><a href="/test"></a></body></html>'
 
-        self.meta = {'/index.html': {'content_type': 'text/html', 'hash': 'd1546d731a9f30cc80127d57142a482b'},
-                     '/test': {'content_type': 'text/html', 'hash': '4539330648b80f94ef3bf911f6d77ac9'}}
+        self.meta = {
+            '/index.html': {
+                'hash': 'd1546d731a9f30cc80127d57142a482b',
+                'headers': [{'Content-Type': 'text/html'}],
+            },
+            '/test': {
+                'hash': '4539330648b80f94ef3bf911f6d77ac9',
+                'headers': [{'Content-Type': 'text/html'}],
+            },
+        }
 
         async def test():
             await self.handler.new_urls.put((yarl.URL(self.root), 0))
@@ -76,8 +84,16 @@ class TestGetBody(unittest.TestCase):
         aiohttp.ClientResponse.read = AsyncMock(return_value=self.content)
         self.expected_content = 'http://example.com/example.png'
         self.return_size = 0
-        self.meta = {'/example.png': {'content_type': 'text/css', 'hash': '5a64beebcd2a6f1cbd00b8370debaa72'},
-                     '/index.html': {'content_type': 'text/css', 'hash': 'd1546d731a9f30cc80127d57142a482b'}}
+        self.meta = {
+            '/example.png': {
+                'hash': '5a64beebcd2a6f1cbd00b8370debaa72',
+                'headers': [{'Content-Type': 'text/css'}],
+            },
+            '/index.html': {
+                'hash': 'd1546d731a9f30cc80127d57142a482b',
+                'headers': [{'Content-Type': 'text/css'}],
+            },
+        }
 
         async def test():
             await self.handler.new_urls.put((yarl.URL(self.root), 0))
@@ -98,8 +114,12 @@ class TestGetBody(unittest.TestCase):
 
         self.content = [b'''.banner { background: url("data://domain/test.txt") }''',
                         b'''.banner { background: url("file://domain/test.txt") }''']
-
-        self.meta = {'/index.html': {'content_type': 'text/css', 'hash': 'd1546d731a9f30cc80127d57142a482b'}}
+        self.meta = {
+            '/index.html': {
+                'hash': 'd1546d731a9f30cc80127d57142a482b',
+                'headers': [{'Content-Type': 'text/css'}],
+            },
+        }
         self.expected_content = 'http://example.com/'
 
         async def test():

--- a/snare/tests/test_server_handle_request.py
+++ b/snare/tests/test_server_handle_request.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 import asyncio
 import argparse
 import shutil
+import multidict
 import os
 import aiohttp
 from aiohttp.http_parser import RawRequestMessage
@@ -30,23 +31,27 @@ class TestHandleRequest(unittest.TestCase):
         args.server_header = "test_server"
         args.slurp_enabled = True
         self.handler = HttpRequestHandler(meta, args, uuid)
-        self.data = {
-            'method': 'GET', 'path': '/',
+        self.request_data = {
+            'method': 'GET',
+            'path': '/',
             'headers': {
-                'Host': 'test_host', 'status': 200
+                'Host': 'test_host',
+                'Content-Type': 'test_type',
             },
+            'status': 200,
             'cookies': {
-                'sess_uuid': 'prev_test_uuid'
-            }
+                'sess_uuid': 'prev_test_uuid',
+            },
         }
         self.loop = asyncio.new_event_loop()
-        self.content = '<html><body></body></html>'
-        self.content_type = 'test_type'
+        self.response_content = '<html><body></body></html>'
+        self.response_headers = multidict.CIMultiDict([("Content-Type", "text/html")])
+        self.response_status = 200
         event_result = dict(response=dict(message=dict(detection={'type': 1}, sess_uuid="test_uuid")))
         RequestHandler = Mock()
         protocol = RequestHandler()
         message = RawRequestMessage(
-            method='POST', path='/', version=HttpVersion(major=1, minor=1), headers=self.data['headers'],
+            method='POST', path='/', version=HttpVersion(major=1, minor=1), headers=self.request_data['headers'],
             raw_headers=None, should_close=None, compression=None, upgrade=None, chunked=None,
             url=URL('http://test_url/')
         )
@@ -54,7 +59,7 @@ class TestHandleRequest(unittest.TestCase):
             message=message, payload=None, protocol=protocol, payload_writer=None,
             task='POST', loop=self.loop
         )
-        self.handler.tanner_handler.create_data = Mock(return_value=self.data)
+        self.handler.tanner_handler.create_data = Mock(return_value=self.request_data)
         self.handler.tanner_handler.submit_data = AsyncMock(return_value=event_result)
         self.handler.submit_slurp = AsyncMock()
         web.Response.add_header = Mock()
@@ -63,7 +68,7 @@ class TestHandleRequest(unittest.TestCase):
         web.Response.write_eof = AsyncMock()
         aiohttp.streams.EmptyStreamReader.read = AsyncMock(return_value=b'con1=test1&con2=test2')
         self.handler.tanner_handler.parse_tanner_response = AsyncMock(
-            return_value=(self.content, self.content_type, self.data['headers'], self.data['headers']['status']))
+            return_value=(self.response_content, self.response_headers, self.response_status))
 
     def test_create_request_data(self):
         async def test():
@@ -77,7 +82,7 @@ class TestHandleRequest(unittest.TestCase):
             await self.handler.handle_request(self.request)
 
         self.loop.run_until_complete(test())
-        self.handler.tanner_handler.submit_data.assert_called_with(self.data)
+        self.handler.tanner_handler.submit_data.assert_called_with(self.request_data)
 
     def test_submit_request_slurp(self):
         async def test():

--- a/snare/tests/test_tanner_handler_parse_tanner_response.py
+++ b/snare/tests/test_tanner_handler_parse_tanner_response.py
@@ -4,6 +4,7 @@ import argparse
 import shutil
 import os
 import json
+import multidict
 from snare.utils.asyncmock import AsyncMock
 from snare.utils.page_path_generator import generate_unique_path
 from snare.tanner_handler import TannerHandler
@@ -17,8 +18,10 @@ class TestParseTannerResponse(unittest.TestCase):
         self.main_page_path = generate_unique_path()
         os.makedirs(self.main_page_path)
         page_dir = self.main_page_path.rsplit('/')[-1]
-        meta_content = {"/index.html": {"hash": "hash_name", "content_type": "text/html"}}
+        meta_content = {"/index.html": {"hash": "hash_name", "headers": [{"Content-Type": "text/html"}]}}
         self.page_content = "<html><body></body></html>"
+        self.headers = multidict.CIMultiDict([("Content-Type", "text/html")])
+        self.status_code = 200
         self.content_type = "text/html"
         with open(os.path.join(self.main_page_path, "hash_name"), 'w') as f:
             f.write(self.page_content)
@@ -36,52 +39,52 @@ class TestParseTannerResponse(unittest.TestCase):
         self.res1 = None
         self.res2 = None
         self.res3 = None
-        self.res4 = None
         self.detection = None
         self.expected_content = None
         self.call_content = None
-        self.expected_header = None
-        self.expected_status_code = None
 
     def test_parse_type_one(self):
         self.detection = {"type": 1}
-        self.call_content = b'<html><body></body></html>'
 
         async def test():
-            (self.res1, self.res2,
-             self.res3, self.res4) = await self.handler.parse_tanner_response(self.requested_name, self.detection)
+            (self.res1, self.res2, self.res3) = \
+                await self.handler.parse_tanner_response(
+                    self.requested_name, self.detection)
 
         self.loop.run_until_complete(test())
-        real_result = [self.res1, self.res2, self.res3, self.res4]
-        expected_result = [self.page_content, self.content_type, {}, 200]
+        real_result = [self.res1, self.res2, self.res3]
+        expected_result = [self.page_content, self.headers, self.status_code]
         self.assertCountEqual(real_result, expected_result)
 
     def test_parse_type_one_query(self):
         self.requested_name = '/?'
         self.detection = {"type": 1}
-        self.call_content = b'<html><body></body></html>'
 
         async def test():
-            (self.res1, self.res2,
-             self.res3, self.res4) = await self.handler.parse_tanner_response(self.requested_name, self.detection)
+            (self.res1, self.res2, self.res3) = \
+                await self.handler.parse_tanner_response(
+                    self.requested_name, self.detection)
 
         self.loop.run_until_complete(test())
-        real_result = [self.res1, self.res2, self.res3, self.res4]
-        expected_result = [self.page_content, self.content_type, {}, 200]
+        real_result = [self.res1, self.res2, self.res3]
+        expected_result = [self.page_content, self.headers, self.status_code]
         self.assertCountEqual(real_result, expected_result)
 
     def test_parse_type_one_error(self):
-        self.detection = {"type": 1}
         self.requested_name = 'something/'
-        self.expected_status_code = 404
+        self.detection = {"type": 1}
+        self.expected_content = None
+        self.headers = multidict.CIMultiDict()
+        self.status_code = 404
 
         async def test():
-            (self.res1, self.res2,
-             self.res3, self.res4) = await self.handler.parse_tanner_response(self.requested_name, self.detection)
+            (self.res1, self.res2, self.res3) = \
+                await self.handler.parse_tanner_response(
+                    self.requested_name, self.detection)
 
         self.loop.run_until_complete(test())
-        real_result = [self.res1, self.res2, self.res3, self.res4]
-        expected_result = [None, None, {}, self.expected_status_code]
+        real_result = [self.res1, self.res2, self.res3]
+        expected_result = [self.expected_content, self.headers, self.status_code]
         self.assertCountEqual(real_result, expected_result)
 
     def test_parse_type_two(self):
@@ -89,64 +92,65 @@ class TestParseTannerResponse(unittest.TestCase):
             "type": 2,
             "payload": {
                 "page": "/index.html",
-                "value": "test"
-            }
+                "value": "test",
+            },
         }
         self.expected_content = b'<html><body><div>test</div></body></html>'
 
         async def test():
-            (self.res1, self.res2,
-             self.res3, self.res4) = await self.handler.parse_tanner_response(self.requested_name, self.detection)
+            (self.res1, self.res2, self.res3) = \
+                await self.handler.parse_tanner_response(
+                    self.requested_name, self.detection)
 
         self.loop.run_until_complete(test())
-        real_result = [self.res1, self.res2, self.res3, self.res4]
-        expected_result = [self.expected_content, self.content_type, {}, 200]
+        real_result = [self.res1, self.res2, self.res3]
+        expected_result = [self.expected_content, self.headers, self.status_code]
         self.assertCountEqual(real_result, expected_result)
 
     def test_parse_type_two_with_headers(self):
-
         self.detection = {
             "type": 2,
             "payload": {
                 "page": "",
                 "value": "test.png",
                 "headers": {
-                    "content-type": "multipart/form-data"
-                }
-            }
+                    "content-type": "multipart/form-data",
+                },
+            },
         }
         self.expected_content = b'test.png'
         self.content_type = 'image/png'
-        self.expected_header = {"content-type": "multipart/form-data"}
+        self.headers = multidict.CIMultiDict([("Content-Type", "multipart/form-data")])
 
         async def test():
-            (self.res1, self.res2,
-             self.res3, self.res4) = await self.handler.parse_tanner_response(self.requested_name, self.detection)
+            (self.res1, self.res2, self.res3) = \
+                await self.handler.parse_tanner_response(
+                    self.requested_name, self.detection)
 
         self.loop.run_until_complete(test())
-        real_result = [self.res1, self.res2, self.res3, self.res4]
-        expected_result = [self.expected_content, self.content_type, self.expected_header, 200]
+        real_result = [self.res1, self.res2, self.res3]
+        expected_result = [self.expected_content, self.headers, self.status_code]
         self.assertCountEqual(real_result, expected_result)
 
     def test_parse_type_two_error(self):
-
         self.detection = {
             "type": 2,
             "payload": {
                 "page": "/something",
-                "value": "test"
-            }
+                "value": "test",
+            },
         }
         self.expected_content = b'<html><body><div>test</div></body></html>'
         self.content_type = r'text/html'
 
         async def test():
-            (self.res1, self.res2,
-             self.res3, self.res4) = await self.handler.parse_tanner_response(self.requested_name, self.detection)
+            (self.res1, self.res2, self.res3) = \
+                await self.handler.parse_tanner_response(
+                    self.requested_name, self.detection)
 
         self.loop.run_until_complete(test())
-        real_result = [self.res1, self.res2, self.res3, self.res4]
-        expected_result = [self.expected_content, self.content_type, {}, 200]
+        real_result = [self.res1, self.res2, self.res3]
+        expected_result = [self.expected_content, self.headers, self.status_code]
         self.assertCountEqual(real_result, expected_result)
 
     def test_parse_type_three(self):
@@ -155,18 +159,20 @@ class TestParseTannerResponse(unittest.TestCase):
             "payload": {
                 "page": "/index.html",
                 "value": "test",
-                "status_code": 200
-            }
+                "status_code": 200,
+            },
         }
         self.expected_content = None
+        self.headers = multidict.CIMultiDict()
 
         async def test():
-            (self.res1, self.res2,
-             self.res3, self.res4) = await self.handler.parse_tanner_response(self.requested_name, self.detection)
+            (self.res1, self.res2, self.res3) = \
+                await self.handler.parse_tanner_response(
+                    self.requested_name, self.detection)
 
         self.loop.run_until_complete(test())
-        real_result = [self.res1, self.res2, self.res3, self.res4]
-        expected_result = [self.expected_content, None, {}, 200]
+        real_result = [self.res1, self.res2, self.res3]
+        expected_result = [self.expected_content, self.headers, self.status_code]
         self.assertCountEqual(real_result, expected_result)
 
     def test_call_handle_html(self):
@@ -175,20 +181,21 @@ class TestParseTannerResponse(unittest.TestCase):
         self.expected_content = self.page_content
 
         async def test():
-            (self.res1, self.res2,
-             self.res3, self.res4) = await self.handler.parse_tanner_response(self.requested_name, self.detection)
+            (self.res1, self.res2, self.res3) = \
+                await self.handler.parse_tanner_response(
+                    self.requested_name, self.detection)
 
         self.loop.run_until_complete(test())
         self.handler.html_handler.handle_content.assert_called_with(self.call_content)
 
     def test_parse_exception(self):
         self.detection = {}
-        self.call_content = b'<html><body></body></html>'
         self.expected_content = self.page_content
 
         async def test():
-            (self.res1, self.res2,
-             self.res3, self.res4) = await self.handler.parse_tanner_response(self.requested_name, self.detection)
+            (self.res1, self.res2, self.res3) = \
+                await self.handler.parse_tanner_response(
+                    self.requested_name, self.detection)
 
         with self.assertRaises(KeyError):
             self.loop.run_until_complete(test())

--- a/snare/utils/snare_helpers.py
+++ b/snare/utils/snare_helpers.py
@@ -91,7 +91,7 @@ def add_meta_tag(page_dir, index_page, config):
 
 def check_meta_file(meta_info):
     for k, v in meta_info.items():
-        if 'hash' in v and 'content_type' in v:
+        if 'hash' in v and any(l in v for l in ['content_type', 'headers']):
             continue
         else:
             return False

--- a/snare/utils/snare_helpers.py
+++ b/snare/utils/snare_helpers.py
@@ -47,7 +47,12 @@ class Converter:
             m = hashlib.md5()
             m.update(fn.encode('utf-8'))
             hash_name = m.hexdigest()
-            self.meta[file_name] = {'hash': hash_name, 'headers': [{"Content-Type": mimetypes.guess_type(file_name)[0]}]}
+            self.meta[file_name] = {
+                'hash': hash_name,
+                'headers': [
+                    {"Content-Type": mimetypes.guess_type(file_name)[0]},
+                ],
+            }
             self.logger.debug('Converting the file as %s ', os.path.join(path, hash_name))
             shutil.copyfile(fn, os.path.join(path, hash_name))
             os.remove(fn)

--- a/snare/utils/snare_helpers.py
+++ b/snare/utils/snare_helpers.py
@@ -47,7 +47,7 @@ class Converter:
             m = hashlib.md5()
             m.update(fn.encode('utf-8'))
             hash_name = m.hexdigest()
-            self.meta[file_name] = {'hash': hash_name, 'content_type': mimetypes.guess_type(file_name)[0]}
+            self.meta[file_name] = {'hash': hash_name, 'headers': [{"Content-Type": mimetypes.guess_type(file_name)[0]}]}
             self.logger.debug('Converting the file as %s ', os.path.join(path, hash_name))
             shutil.copyfile(fn, os.path.join(path, hash_name))
             os.remove(fn)


### PR DESCRIPTION
Some websites might have interesting headers. This pull request adds code to store such headers and subsequently serve them.

The default `Server: nginx/1.3.8` header is also removed in favour of the "cloned" one, but it's still possible to specify a different server with the command line switch.