### PR TITLE
Fix internal server error due to unexpected mimetype

### DIFF
--- a/snare/tanner_handler.py
+++ b/snare/tanner_handler.py
@@ -53,7 +53,7 @@ class TannerHandler():
                     timeout=10.0
                 )
                 try:
-                    event_result = await r.json()
+                    event_result = await r.json(content_type=None)
                 except json.decoder.JSONDecodeError as e:
                     self.logger.error('Error submitting data: {} {}'.format(e, data))
                 finally:


### PR DESCRIPTION
I've fixed the `Internal Server Error` problem.

Issue #224 and my [comment](https://github.com/mushorg/snare/issues/224#issuecomment-590468689) on that explains the problem.

Also if setting `content_type=None` isn't considered good practice then 
we can set that to mimetype `text/plain` as reported in the traceback

@afeena @adepasquale please review this PR and let me know if any changers are required.