### PR TITLE
Fixed #256 -- TypeError in `print_color`

### DIFF
--- a/snare/utils/snare_helpers.py
+++ b/snare/utils/snare_helpers.py
@@ -129,4 +129,4 @@ def print_color(msg, mode='INFO'):
         color = colors[mode]
     except KeyError:
         color = colors['INFO']
-    print(color + msg + '\033[0m')
+    print(color + str(msg) + '\033[0m')


### PR DESCRIPTION
handled the case if msg passed is not a string object to the `print_color` object due to which the return expression was throwing an error.