### PR TITLE
accurate exception handling in page.close

### DIFF
--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -183,10 +183,12 @@ class BaseCloner:
             self.meta[file_name]["headers"] = headers
             self.meta[file_name]["content_type"] = content_type
 
-            if content_type == "text/html":
+            if not content_type:
+                pass
+            elif "text/html" in content_type:
                 soup = await self.replace_links(data, level)
                 data = str(soup).encode()
-            elif content_type == "text/css":
+            elif "text/css" in content_type:
                 css = cssutils.parseString(data, validate=self.css_validate)
                 for carved_url in cssutils.getUrls(css):
                     if carved_url.startswith("data"):

--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -280,7 +280,7 @@ class CloneRunner:
 
     async def run(self):
         if not self.runner:
-            raise Exception("Error initializing cloner!")
+            raise Exception("Error running cloner! - Cloner instance is None")
         if type(self.runner) == SimpleCloner:
             self.driver = aiohttp.ClientSession()
         else:
@@ -296,7 +296,7 @@ class CloneRunner:
 
     async def close(self):
         if not self.runner:
-            raise Exception("Error initializing cloner!")
+            raise Exception("Error closing cloner! - Cloner instance is None")
         with open(os.path.join(self.runner.target_path, "meta.json"), "w") as mj:
             json.dump(self.runner.meta, mj)
         if self.driver:

--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -12,6 +12,7 @@ from bs4 import BeautifulSoup
 from asyncio import Queue
 from collections import defaultdict
 from pyppeteer import launch
+from pyppeteer.errors import PageError
 
 from snare.utils.snare_helpers import print_color
 
@@ -258,8 +259,8 @@ class HeadlessCloner(BaseCloner):
             try:
                 if page:
                     await page.close()
-            except Exception as err:
-                print_color(str(err), "WARNING")
+            except PageError as err: # when KeyboardInterrupt is raised midway cloning
+                self.logger.error(err)
 
         return [redirect_url, data, headers, content_type]
 

--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -12,7 +12,7 @@ from bs4 import BeautifulSoup
 from asyncio import Queue
 from collections import defaultdict
 from pyppeteer import launch
-from pyppeteer.errors import PageError
+from pyppeteer.errors import PageError, NetworkError, TimeoutError
 
 from snare.utils.snare_helpers import print_color
 
@@ -254,7 +254,7 @@ class HeadlessCloner(BaseCloner):
             if response_url.with_scheme("http") != current_url.with_scheme("http"):
                 redirect_url = response_url
             data = await response.buffer()
-        except Exception as err:
+        except (ConnectionError, NetworkError, TimeoutError, PageError) as err:
             self.logger.error(err)
             await self.new_urls.put({"url": current_url, "level": level, "try_count": try_count + 1})
         finally:


### PR DESCRIPTION
* If `KeyboardInterrupt` is raised midway headless cloning, then a `PageError` is raised while closing the `Page` object. The raised exception can be safely ignored as the execution comes to a halt after it but there is no way to avoid a try-except in the finally part of `HeadlessCloner.fetch_data`.
* The `Content-Type` header might sometimes contain character set information like, `Content-Type: text/html; charset=utf-8`. To accommodate this, we can check for *presence* rather than *equality*. Sometimes, `Content-Type` is not set and to avoid `TypeError` by iteration in a `NoneType` object, we check if it is not `None` first.