### PR TITLE
newer libraries and bug fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-aiohttp==3.7.4
-aiohttp_jinja2==1.1.0
-beautifulsoup4==4.6.3
-cssutils==1.0.2
-gitpython==3.1.0
-pycodestyle==2.4.0
-pyppeteer==0.2.5
+aiohttp~=3.7
+aiohttp-jinja2~=1.4
+beautifulsoup4~=4.9
+cssutils~=2.3
+GitPython~=3.1
+pycodestyle~=2.7
+pyppeteer~=0.2

--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -195,6 +195,8 @@ class BaseCloner:
                         carved_url = self.root.join(carved_url)
                     if carved_url.with_scheme("http").human_repr() not in self.visited_urls:
                         await self.new_urls.put({"url": carved_url, "level": level + 1, "try_count": 0})
+            if type(data) == str:
+                data = data.encode()
 
             try:
                 with open(os.path.join(self.target_path, hash_name), "wb") as index_fh:


### PR DESCRIPTION
### Requirements

* `requirements.txt` has been updated with newer modules after testing.
* Requirements now make use of `~=` instead of `==` to allow newer versions without breaking changes (due to major releases).
* For example, assume that the latest version of `my-module` is **3.2** in the 3.x release cycle and **2.9** in the 2.x release cycle.
* `my-module~=2.3~` in `requirements.txt` will download `v2.9` of `my-module`.

### Minor bug fix

* While downloading CSS files, `response.buffer()` in `HeadlessCloner.fetch_data` returns a `string` instead of the usual `bytes`. This caused the write operation in binary mode to fail.
* Thus, a check to properly encode the data string into bytes has been introduced.