### PR TITLE
error templating fixes

### DIFF
--- a/snare/cloner.py
+++ b/snare/cloner.py
@@ -267,7 +267,7 @@ class HeadlessCloner(BaseCloner):
             try:
                 if page:
                     await page.close()
-            except PageError as err: # when KeyboardInterrupt is raised midway cloning
+            except PageError as err:  # when KeyboardInterrupt is raised midway cloning
                 self.logger.error(err)
 
         return [redirect_url, data, headers, content_type]


### PR DESCRIPTION
* Snare cannot be made completely non-fingerprint-able because a malformed request triggers a 400 exception which cannot be handled by aiohttp _at the moment_ (ref [aiohttp#5358](https://github.com/aio-libs/aiohttp/issues/5358) and [aiohttp#3287](https://github.com/aio-libs/aiohttp/issues/3287)).
* This PR ensures that proper headers are assigned during 404 and 500 errors.
* `HttpRequestHandler.remove_default_server_header` removes the default Server header to prevent leakage of the aiohttp server banner.