### PR TITLE
Preventing cloner from throwing unbound error

### DIFF
--- a/bin/clone
+++ b/bin/clone
@@ -70,8 +70,8 @@ def main():
 
     logger.Logger.create_clone_logger(log_file, __package__)
     print_color("  Logs will be stored in {}".format(log_file), "INFO", end="")
+    start = datetime.now()
     try:
-        start = datetime.now()
         cloner = Cloner(
             args.target, int(args.max_depth), args.css_validate, default_path
         )
@@ -82,6 +82,7 @@ def main():
         end = datetime.now() - start
     finally:
         print("")
+        end = datetime.now() - start
         print_color("-" * 36 + ">SUMMARY<" + "-" * 36, "INFO")
         print_color(
             "\tTotal number of URLs cloned: {}".format(str(cloner.counter)), "INFO"

--- a/bin/clone
+++ b/bin/clone
@@ -21,61 +21,85 @@ from datetime import datetime
 
 from snare.cloner import Cloner
 from snare.utils import logger
-from snare.utils.snare_helpers import check_privileges, print_color, str_to_bool
+from snare.utils.snare_helpers import (check_privileges, print_color,
+                                       str_to_bool)
 
 
 def main():
     loop = asyncio.get_event_loop()
     parser = argparse.ArgumentParser()
-    parser.add_argument("--target", help="domain of the site to be cloned", required=True)
-    parser.add_argument("--max-depth", help="max depth of the cloning", required=False, default=sys.maxsize)
+    parser.add_argument(
+        "--target", help="domain of the site to be cloned", required=True
+    )
+    parser.add_argument(
+        "--max-depth",
+        help="max depth of the cloning",
+        required=False,
+        default=sys.maxsize,
+    )
     parser.add_argument("--log-path", help="path to the log file")
-    parser.add_argument("--css-validate", help="set whether css validation is required", type=str_to_bool, default=None)
-    parser.add_argument("--path", help="path to save the page to be cloned", required=False, default="/opt/")
+    parser.add_argument(
+        "--css-validate",
+        help="set whether css validation is required",
+        type=str_to_bool,
+        default=None,
+    )
+    parser.add_argument(
+        "--path",
+        help="path to save the page to be cloned",
+        required=False,
+        default="/opt/",
+    )
     args = parser.parse_args()
-    default_path = os.path.join(args.path, 'snare')
+    default_path = os.path.join(args.path, "snare")
 
     if args.log_path:
         log_file = os.path.join(args.log_path, "clone.log")
     else:
-        log_file = os.path.join(default_path, 'clone.log')
+        log_file = os.path.join(default_path, "clone.log")
 
     try:
         check_privileges(default_path)
         check_privileges(os.path.dirname(log_file))
     except PermissionError as err:
-        print_color(err, 'WARNING')
+        print_color(err, "WARNING")
         sys.exit(1)
 
-    if not os.path.exists('{}/pages'.format(default_path)):
-        os.makedirs('{}/pages'.format(default_path))
+    if not os.path.exists("{}/pages".format(default_path)):
+        os.makedirs("{}/pages".format(default_path))
 
     logger.Logger.create_clone_logger(log_file, __package__)
     print_color("  Logs will be stored in {}".format(log_file), "INFO", end="")
     try:
         start = datetime.now()
-        cloner = Cloner(args.target, int(args.max_depth), args.css_validate, default_path)
+        cloner = Cloner(
+            args.target, int(args.max_depth), args.css_validate, default_path
+        )
         loop.run_until_complete(cloner.get_root_host())
         loop.run_until_complete(cloner.run())
-        end = datetime.now()-start
+        end = datetime.now() - start
     except KeyboardInterrupt:
-        end = datetime.now()-start
+        end = datetime.now() - start
     finally:
         print("")
-        print_color("-"*36+">SUMMARY<"+"-"*36, "INFO")
-        print_color('\tTotal number of URLs cloned: {}'.format(str(cloner.counter)), "INFO")
-        print_color('\tTime elapsed: {}'.format(str(end)), "INFO")
-        print_color('\tCloned directory: {}'.format(cloner.target_path), "INFO")
-        print_color('-'*82, "INFO")
+        print_color("-" * 36 + ">SUMMARY<" + "-" * 36, "INFO")
+        print_color(
+            "\tTotal number of URLs cloned: {}".format(str(cloner.counter)), "INFO"
+        )
+        print_color("\tTime elapsed: {}".format(str(end)), "INFO")
+        print_color("\tCloned directory: {}".format(cloner.target_path), "INFO")
+        print_color("-" * 82, "INFO")
 
 
-if __name__ == '__main__':
-    print("""
+if __name__ == "__main__":
+    print(
+        """
     ______ __      ______ _   ____________
    / ____// /     / __  // | / / ____/ __ \\
   / /    / /     / / / //  |/ / __/ / /_/ /
  / /___ / /____ / /_/ // /|  / /___/ _, _/
 /_____//______//_____//_/ |_/_____/_/ |_|
 
-    """)
+    """
+    )
     main()


### PR DESCRIPTION
When I was investigating #278 the only issue I found with cloner was this:

```
Traceback (most recent call last):                                                                                                                           
  File "/home/mzfr/dev/snare/venv/bin/clone", line 4, in <module>                                                                                            
    __import__('pkg_resources').run_script('Snare==0.3.0', 'clone')                                                                                          
  File "/home/mzfr/dev/snare/venv/lib/python3.10/site-packages/pkg_resources/__init__.py", line 672, in run_script                                           
    self.require(requires)[0].run_script(script_name, ns)                                                                                                    
  File "/home/mzfr/dev/snare/venv/lib/python3.10/site-packages/pkg_resources/__init__.py", line 1479, in run_script                                          
    exec(script_code, namespace, namespace)                                                                                                                  
  File "/home/mzfr/dev/snare/venv/lib/python3.10/site-packages/Snare-0.3.0-py3.10.egg/EGG-INFO/scripts/clone", line 81, in <module>                          
  File "/home/mzfr/dev/snare/venv/lib/python3.10/site-packages/Snare-0.3.0-py3.10.egg/EGG-INFO/scripts/clone", line 67, in main                              
UnboundLocalError: local variable 'end' referenced before assignment
```

this PR fixes that issue