### PR TITLE
Update snare

### DIFF
--- a/bin/snare
+++ b/bin/snare
@@ -133,7 +133,7 @@ if __name__ == '__main__':
     page_group.add_argument("--page-dir", help="name of the folder to be served")
     page_group.add_argument("--list-pages", help="list available pages", action='store_true')
     parser.add_argument("--index-page", help="file name of the index page", default='index.html')
-    parser.add_argument("--port", help="port to listen on", default='8080')
+    parser.add_argument("--port", type=int, help="port to listen on", default='8080')
     parser.add_argument("--host-ip", help="host ip to bind to", default='127.0.0.1')
     parser.add_argument("--debug", help="run web server in debug mode", default=False)
     parser.add_argument("--tanner", help="ip of the tanner service", default='tanner.mushmush.org')


### PR DESCRIPTION
I've been facing an error when I tried to run Snare. The environment was a Docker Container consisting of an Ubuntu image, version 20.04.

The error I encountered was "The port is required to be int." even using the flag "--port".

I've also tried to change the Docker image version to 22.04, and updated the `aiohttp` library to the most updated version. Even though, I got no success unless changing the type of the argument.

